### PR TITLE
Adjust RLBench token training config

### DIFF
--- a/lift3d/config/train_rlbench_token.yaml
+++ b/lift3d/config/train_rlbench_token.yaml
@@ -1,14 +1,13 @@
 # ----------------- 基础继承 -----------------
 defaults:
+  - train_rlbench
   - agent: token_voxel_grasp            # ★ 新增
   - loss_cfg: grasp_loss                # ★ 新增
-  - benchmark: rlbench                 
 
 # --------- 可按需要覆盖全局超参 ---------------
 seed: 0
-trainer:
-  max_epochs: 100
 dataloader:
   batch_size: 8
-optimizer:
-  lr: 1e-4
+train:
+  learning_rate: 1e-4
+  num_epochs: 100


### PR DESCRIPTION
## Summary
- inherit base `train_rlbench` config for token model training
- specify the `token_voxel_grasp` agent and `grasp_loss`
- replace old trainer/optimizer settings with a `train` block

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6860acf70a248321a428e3a3780bcef0