### PR TITLE
Fix future import position

### DIFF
--- a/lift3d/models/actor.py
+++ b/lift3d/models/actor.py
@@ -1,3 +1,8 @@
+from __future__ import annotations
+
+# lift3d/models/actor.py  (新增部分类)
+# ---------------------------------------------------------------
+
 import abc
 from typing import List
 
@@ -11,9 +16,6 @@ from lift3d.models.mlp.batchnorm_mlp import BatchNormMLP
 from lift3d.models.mlp.mlp import MLP
 
 
-# lift3d/models/actor.py  (新增部分类)
-# ---------------------------------------------------------------
-from __future__ import annotations
 import torch.nn.functional as F
 from typing import Dict, Tuple
 


### PR DESCRIPTION
## Summary
- move `from __future__ import annotations` to the very top of `lift3d/models/actor.py`

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68610b6bb1f48321912214133b07a244